### PR TITLE
ci: aggiunge supporto rami hotfix nei workflow CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'v[0-9]*'
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
           MAX_LENGTH=72
-          PATTERN='^(feat|fix|docs|chore|refactor|test|perf|ci|build)(\(.+\))?: '
+          PATTERN='^(feat|fix|docs|chore|refactor|test|perf|ci|build)(\(.+\))?!?: '
 
           if ! echo "$TITLE" | grep -qE "$PATTERN"; then
             echo "❌ Il titolo deve iniziare con un prefisso conventional commit (feat:, fix:, docs:, ...)"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'v[0-9]*'
 
 permissions:
   contents: write
@@ -20,3 +21,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: ${{ github.ref_name }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,8 +10,8 @@
     { "type": "refactor", "section": "Refactoring", "hidden": false },
     { "type": "test", "section": "Tests", "hidden": false },
     { "type": "perf", "section": "Performance", "hidden": false },
-    { "type": "ci", "section": "CI/CD", "hidden": false },
-    { "type": "build", "section": "Build", "hidden": false }
+    { "type": "ci", "section": "CI/CD", "hidden": true },
+    { "type": "build", "section": "Build", "hidden": true }
   ],
   "packages": {
     ".": {


### PR DESCRIPTION
## Descrizione
<!-- Spiega brevemente lo scopo di questa PR. -->
La configurazione di `release-please` per la distribuzione delle release e la ci, sono aggiornate seguendo il nuovo standard
## Riferimenti Issue
<!-- Collega la Issue risolta (es. Closes #). -->
Manutenzione - nessuna issue collegata

## Modifiche Effettuate
<!-- Elenca in modo sintetico le parti di codice toccate. -->
- aggiunge trigger per i rami di hotfix per la ci e release-please
- aggiorna regex per includere pr di breaking changes
- nasconde le sezioni ci e build dal changelog

## Checklist di Controllo
<!-- Spunta le caselle sostituendo [ ] con [x] per garantire gli standard del progetto. -->
- [x] Il titolo della PR segue i Conventional Commits (`feat:`, `fix:`, `chore:`, ecc.).
- [ ] Il codice supera i controlli di linting e formattazione.
- [ ] La build locale completa senza errori (`pnpm build`).
- [x] Ho testato manualmente i cambiamenti prima di aprire la PR.
