### PR TITLE
chore: uniforma e semplifica gli script pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Lint
-        run: pnpm lint:check
+        run: pnpm lint
 
       - name: Type Check
-        run: pnpm type-check
+        run: pnpm typecheck
 
       - name: Build
         run: pnpm build

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,2 @@
-pnpm lint:check
-pnpm type-check
+pnpm lint
+pnpm typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,8 @@ pnpm preview          # Preview build locale
 
 **Verifica (pre-push):**
 ```bash
-pnpm lint:check       # Controllo ESLint
-pnpm type-check       # TypeScript type checking (noEmit)
+pnpm lint             # Controllo ESLint
+pnpm typecheck        # TypeScript type checking (noEmit)
 ```
 
 La build produzione (`pnpm build`) viene eseguita in CI.

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "build": "vite build --minify",
     "preview": "vite preview",
     "prepare": "husky",
-    "lint": "eslint . --ext js,jsx,ts,tsx",
-    "lint:fix": "eslint . --ext js,jsx,ts,tsx --fix",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "typecheck": "tsc --noEmit -p tsconfig.app.json && tsc --noEmit -p tsconfig.node.json"

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "build": "vite build --minify",
     "preview": "vite preview",
     "prepare": "husky",
-    "lint:check": "eslint . --ext js,jsx,ts,tsx",
+    "lint": "eslint . --ext js,jsx,ts,tsx",
     "lint:fix": "eslint . --ext js,jsx,ts,tsx --fix",
-    "format:check": "prettier --check .",
+    "format": "prettier --check .",
     "format:fix": "prettier --write .",
-    "type-check": "tsc --noEmit -p tsconfig.app.json && tsc --noEmit -p tsconfig.node.json"
+    "typecheck": "tsc --noEmit -p tsconfig.app.json && tsc --noEmit -p tsconfig.node.json"
   },
   "dependencies": {
     "@tanstack/react-router": "^1.132.23",


### PR DESCRIPTION
- **chore: rinomina e semplifica script pnpm**
- **chore: aggiorna riferimenti script in CI e pre-push**
- **chore: rimuove flag --ext ridondante dagli script lint**
- **docs: aggiorna nomi script in AGENTS.md**

## Descrizione
<!-- Spiega brevemente lo scopo di questa PR. -->
Uniforma i nomi degli script pnpm allo stile del progetto `server-portfolio`, rimuovendo suffissi ridondanti e il flag `--ext` non piu' neccessario con Eslint flat config.
## Riferimenti Issue
<!-- Collega la Issue risolta (es. Closes #). -->
Manutenzione - nessuna issue collegata

## Modifiche Effettuate
<!-- Elenca in modo sintetico le parti di codice toccate. -->
- Rinominati script: `lint:check` → `lint`, `type-check` → `typecheck`, `format:check` → `format`
- Rimosso flag `--ext js,jsx,ts,tsx` dagli script lint (gestito da `files` in `eslint.config.js`)
- Aggiornati riferimenti in workflow CI e hook `pre-push`
- Aggiornata documentazione in `AGENTS.md`

## Checklist di Controllo
<!-- Spunta le caselle sostituendo [ ] con [x] per garantire gli standard del progetto. -->
- [x] Il titolo della PR segue i Conventional Commits (`feat:`, `fix:`, `chore:`, ecc.).
- [x] Il codice supera i controlli di linting e formattazione.
- [x] La build locale completa senza errori (`pnpm build`).
- [x] Ho testato manualmente i cambiamenti prima di aprire la PR.
