### PR TITLE
fix: aggiunge attributi aria alla sidebar e ai bottoni

### DIFF
--- a/src/components/organisms/Navbar/Navbar.tsx
+++ b/src/components/organisms/Navbar/Navbar.tsx
@@ -38,7 +38,13 @@ export const Navbar = () => {
 
             {/* Menu Mobile: Bottone menu + SideBar */}
             <div className="lg:hidden">
-              <button onClick={() => setIsOpen(true)} aria-expanded={isOpen} aria-controls='sidebar' className="btn" aria-label='Apri menu'>
+              <button
+                onClick={() => setIsOpen(true)}
+                aria-expanded={isOpen}
+                aria-controls="sidebar"
+                className="btn"
+                aria-label="Apri menu"
+              >
                 Menu
               </button>
 

--- a/src/components/organisms/Navbar/Navbar.tsx
+++ b/src/components/organisms/Navbar/Navbar.tsx
@@ -38,7 +38,7 @@ export const Navbar = () => {
 
             {/* Menu Mobile: Bottone menu + SideBar */}
             <div className="lg:hidden">
-              <button onClick={() => setIsOpen(true)} className="btn">
+              <button onClick={() => setIsOpen(true)} aria-expanded={isOpen} aria-controls='sidebar' className="btn" aria-label='Apri menu'>
                 Menu
               </button>
 

--- a/src/components/organisms/Navbar/SideBar.tsx
+++ b/src/components/organisms/Navbar/SideBar.tsx
@@ -45,7 +45,6 @@ export const SideBar = ({ isOpen, setIsOpen }: SideBarProps) => {
       {/* Contenitore principale della SideBar */}
       <div
         role="dialog"
-        aria-modal="true"
         id="sidebar"
         aria-hidden={!isOpen}
         className={`bg-base-200 fixed inset-y-0 top-0 right-0 z-20 h-screen w-[70%] transform shadow-lg ${mounted ? 'transition-transform duration-300 ease-in-out' : ''}lg:hidden ${

--- a/src/components/organisms/Navbar/SideBar.tsx
+++ b/src/components/organisms/Navbar/SideBar.tsx
@@ -44,6 +44,10 @@ export const SideBar = ({ isOpen, setIsOpen }: SideBarProps) => {
 
       {/* Contenitore principale della SideBar */}
       <div
+        role="dialog"
+        aria-modal="true"
+        id="sidebar"
+        aria-hidden={!isOpen}
         className={`bg-base-200 fixed inset-y-0 top-0 right-0 z-20 h-screen w-[70%] transform shadow-lg ${mounted ? 'transition-transform duration-300 ease-in-out' : ''}lg:hidden ${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
@@ -53,6 +57,7 @@ export const SideBar = ({ isOpen, setIsOpen }: SideBarProps) => {
             <button
               onClick={() => setIsOpen(false)}
               className="btn btn-error btn-circle"
+              aria-label="Chiudi menu"
             >
               <img src={CloseIcon} alt="close" />
             </button>


### PR DESCRIPTION
## Descrizione
<!-- Spiega brevemente lo scopo di questa PR. -->
Aggiunge attributi ARIA mancanti ai bottoni della navbar e alla sidebar per migliorare l'accessibilita' con screen reader. Gli elementi interattivi ora dichiarano correttamente il loro stato e ruolo.
## Riferimenti Issue
<!-- Collega la Issue risolta (es. Closes #). -->
Closes #147

## Modifiche Effettuate
<!-- Elenca in modo sintetico le parti di codice toccate. -->
- aggiunge `aria-expande={isOpen}`, `aria-controls="sidebar"` e `aria-label="Apri menu` al bottone della navbar
- aggiunge `role="dialog"`, `id="sidebar` e `aria-hidden={!isOpen}` al contenitore pricipale della sidebar
- aggiunge `aria-label="Chiudi menu"` al bottone della sidebar
- controllato con `lighthouse`, `axe DevTolls` sara' anche buono ma e' quasi tutto bloccato da pay wall
## Checklist di Controllo
<!-- Spunta le caselle sostituendo [ ] con [x] per garantire gli standard del progetto. -->
- [x] Il titolo della PR segue i Conventional Commits (`feat:`, `fix:`, `chore:`, ecc.).
- [x] Il codice supera i controlli di linting e formattazione.
- [x] La build locale completa senza errori (`pnpm build`).
- [x] Ho testato manualmente i cambiamenti prima di aprire la PR.
