### PR TITLE
fix: sostituisce `srcSet` con `src` nelle icone social

### DIFF
--- a/src/components/molecules/Social/Icon.tsx
+++ b/src/components/molecules/Social/Icon.tsx
@@ -30,7 +30,7 @@ export const Icon: React.FC<IconType> = ({ name, icon, link }) => {
       rel="noopener noreferrer"
       className="group flex items-center gap-4 hover:space-x-4 lg:space-x-0"
     >
-      <img srcSet={IconImg} alt="" className="size-5" />
+      <img src={IconImg} alt="" className="size-5" />
       <span className="max-h-6 overflow-hidden font-semibold uppercase transition-all duration-700 ease-in-out group-hover:max-w-xs lg:max-w-0 lg:opacity-0 group-hover:lg:opacity-100">
         {name}
       </span>


### PR DESCRIPTION
## Descrizione
<!-- Spiega brevemente lo scopo di questa PR. -->
Sostituito `srcSet` nelle icone social del footer con `src`. Passando una sola icona non aveva senso usare l'attibuto `srcSet` che viene usato per fornire varie alternative di dimensione e densita'.
## Riferimenti Issue
<!-- Collega la Issue risolta (es. Closes #). -->
Closes #149

## Modifiche Effettuate
<!-- Elenca in modo sintetico le parti di codice toccate. -->
- sostituisce `srcSet` con `src` in `Icon.tsx`

## Checklist di Controllo
<!-- Spunta le caselle sostituendo [ ] con [x] per garantire gli standard del progetto. -->
- [x] Il titolo della PR segue i Conventional Commits (`feat:`, `fix:`, `chore:`, ecc.).
- [x] Il codice supera i controlli di linting e formattazione.
- [x] La build locale completa senza errori (`pnpm build`).
- [x] Ho testato manualmente i cambiamenti prima di aprire la PR.
