### PR TITLE
fix: corregge testo alt delle icone skill

### DIFF
--- a/src/components/organisms/SectionSkill/SkillCard.tsx
+++ b/src/components/organisms/SectionSkill/SkillCard.tsx
@@ -31,7 +31,7 @@ export const SkillCard = ({ name, icon, carousel }: SkillCardProps) => {
   if (carousel) {
     return (
       <div className="bg-base-300 rounded-md p-2 shadow-md">
-        <img src={icon} alt={name + 'icon'} className={`${iconSize}`} />
+        <img src={icon} alt={`${name} icon`} className={`${iconSize}`} />
       </div>
     );
   }
@@ -42,7 +42,7 @@ export const SkillCard = ({ name, icon, carousel }: SkillCardProps) => {
       data-tip={name}
     >
       <p className="text-primary font-semibold uppercase md:hidden">{name}</p>
-      <img src={icon} alt={name + 'icon'} className={`${iconSize}`} />
+      <img src={icon} alt={`${name} icon`} className={`${iconSize}`} />
     </li>
   );
 };


### PR DESCRIPTION
## Descrizione
<!-- Spiega brevemente lo scopo di questa PR. -->
Corregge il testo alternativo delle icone nel componente `SkillCard` aggiungendo uno spazio tra il nome della tecnologia e la parola "icon". Prima uno screen reader leggeva stringhe come "Reacticon", ora legge "React icon"
## Riferimenti Issue
<!-- Collega la Issue risolta (es. Closes #). -->
Closes #151

## Modifiche Effettuate
<!-- Elenca in modo sintetico le parti di codice toccate. -->
- sostituisce `alt={name + 'icon'}` con \`alt={\`${name} icon\`}`

## Checklist di Controllo
<!-- Spunta le caselle sostituendo [ ] con [x] per garantire gli standard del progetto. -->
- [x] Il titolo della PR segue i Conventional Commits (`feat:`, `fix:`, `chore:`, ecc.).
- [x] Il codice supera i controlli di linting e formattazione.
- [x] La build locale completa senza errori (`pnpm build`).
- [x] Ho testato manualmente i cambiamenti prima di aprire la PR.
