### PR TITLE
fix: sostituisce Link con tag a per URL esterni

### DIFF
--- a/src/features/projects/components/Header.tsx
+++ b/src/features/projects/components/Header.tsx
@@ -1,5 +1,3 @@
-import { Link } from '@tanstack/react-router';
-
 /**
  * Componente HeaderProject - Intestazione pagina progetti
  *
@@ -28,32 +26,32 @@ export const HeaderProject = () => {
         </p>
         <p>
           Vuoi scoprire di più? Visita il mio{' '}
-          <Link
-            to="https://www.frontendmentor.io/profile/Smailen5"
+          <a
+            href="https://www.frontendmentor.io/profile/Smailen5"
             target="_blank"
             rel="noopener noreferrer"
             className="link link-primary"
           >
             profilo Frontend Mentor
-          </Link>{' '}
+          </a>{' '}
           per vedere le sfide completate o il mio{' '}
-          <Link
-            to="https://github.com/Smailen5"
+          <a
+            href="https://github.com/Smailen5"
             target="_blank"
             rel="noopener noreferrer"
             className="link link-primary"
           >
             profilo GitHub
-          </Link>{' '}
+          </a>{' '}
           per tutti i progetti, incluso il{' '}
-          <Link
-            to="https://github.com/Smailen5/portfolio-website"
+          <a
+            href="https://github.com/Smailen5/portfolio-website"
             target="_blank"
             rel="noopener noreferrer"
             className="link link-primary"
           >
             codice sorgente di questo sito
-          </Link>
+          </a>
           .
         </p>
       </header>


### PR DESCRIPTION
## Descrizione
<!-- Spiega brevemente lo scopo di questa PR. -->
Sostituisce `Link` di Tanstack con link `a` nativi, cambia la proprieta' `to` in `href`. Non ho toccato `target` e `rel`, erano gia' impostati correttamente
## Riferimenti Issue
<!-- Collega la Issue risolta (es. Closes #). -->
Closes #146

## Modifiche Effettuate
<!-- Elenca in modo sintetico le parti di codice toccate. -->
- sostituisce i `Link` di Tanstack con `a` nativo

## Checklist di Controllo
<!-- Spunta le caselle sostituendo [ ] con [x] per garantire gli standard del progetto. -->
- [x] Il titolo della PR segue i Conventional Commits (`feat:`, `fix:`, `chore:`, ecc.).
- [x] Il codice supera i controlli di linting e formattazione.
- [x] La build locale completa senza errori (`pnpm build`).
- [x] Ho testato manualmente i cambiamenti prima di aprire la PR.
