### PR TITLE
fix: rimuove params stringa dai Link di navigazione

### DIFF
--- a/src/components/organisms/Navbar/Navbar.tsx
+++ b/src/components/organisms/Navbar/Navbar.tsx
@@ -58,7 +58,6 @@ export const Navbar = () => {
                   <Link
                     key={link.params}
                     to={link.linkTo}
-                    params={link.params}
                     className="capitalize"
                   >
                     {link.params}

--- a/src/components/organisms/Navbar/Navbar.tsx
+++ b/src/components/organisms/Navbar/Navbar.tsx
@@ -56,11 +56,11 @@ export const Navbar = () => {
               <nav className="flex items-center gap-4">
                 {NAVIGATION_LINKS.map(link => (
                   <Link
-                    key={link.params}
+                    key={link.label}
                     to={link.linkTo}
                     className="capitalize"
                   >
-                    {link.params}
+                    {link.label}
                   </Link>
                 ))}
                 <CurriculumDownload />

--- a/src/components/organisms/Navbar/SideBar.tsx
+++ b/src/components/organisms/Navbar/SideBar.tsx
@@ -65,13 +65,12 @@ export const SideBar = ({ isOpen, setIsOpen }: SideBarProps) => {
           <nav className="flex flex-col gap-4">
             {NAVIGATION_LINKS.map(link => (
               <Link
-                key={link.params}
+                key={link.label}
                 to={link.linkTo}
-                params={link.params}
                 className="capitalize"
                 onClick={closeSideBar}
               >
-                {link.params}
+                {link.label}
               </Link>
             ))}
             <CurriculumDownload closeSideBar={closeSideBar} />

--- a/src/shared/constants/navigation.ts
+++ b/src/shared/constants/navigation.ts
@@ -1,8 +1,8 @@
 export const NAVIGATION_LINKS = [
-  { linkTo: '/', params: 'home' },
-  { linkTo: '/projects', params: 'projects' },
-  { linkTo: '/contact', params: 'contact' },
-  { linkTo: '/about', params: 'about' },
+  { linkTo: '/', label: 'home' },
+  { linkTo: '/projects', label: 'projects' },
+  { linkTo: '/contact', label: 'contact' },
+  { linkTo: '/about', label: 'about' },
 ] as const;
 
 export type NavigationLink = (typeof NAVIGATION_LINKS)[number];


### PR DESCRIPTION
## Descrizione
<!-- Spiega brevemente lo scopo di questa PR. -->
Rimuove la prop `params` passata come stringa ai componenti `Link` di TanStack Router nella navbar e nella sidebar. Per le rotte statiche `params` non e' necessario e, dove richiesto, deve essere un oggetto.
## Riferimenti Issue
<!-- Collega la Issue risolta (es. Closes #). -->
Closes #144

## Modifiche Effettuate
<!-- Elenca in modo sintetico le parti di codice toccate. -->
- Rinomina il campo `params` in `label` in `src/shared/constants/navigation.ts`
- Aggiorna `src/components/organisms/Navbar/Navbar.tsx` per usare `link.label` come `key` e `children`
- Aggiorna `src/components/organisms/Navbar/SideBar.tsx` per usare `link.label` e rimuovere `params` dal `Link`

## Checklist di Controllo
<!-- Spunta le caselle sostituendo [ ] con [x] per garantire gli standard del progetto. -->
- [x] Il titolo della PR segue i Conventional Commits (`feat:`, `fix:`, `chore:`, ecc.).
- [x] Il codice supera i controlli di linting e formattazione.
- [x] La build locale completa senza errori (`pnpm build`).
- [x] Ho testato manualmente i cambiamenti prima di aprire la PR.
