### PR TITLE
fix: rende efficace il controllo useTheme fuori dal provider

### DIFF
--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -11,10 +11,7 @@ interface ThemeContextType {
 
 const defaultTheme: Theme = 'light';
 
-const ThemeContext = createContext<ThemeContextType>({
-  theme: defaultTheme,
-  setTheme: () => null,
-});
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 interface ThemeProviderProps {
   children: React.ReactNode;


### PR DESCRIPTION
## Descrizione
<!-- Spiega brevemente lo scopo di questa PR. -->
Corregge il controllo di errore in `useTheme` creando il `ThemeContext` con valore di default `undefined`. In questo modo, se `useTheme` viene chiamato fuori da `ThemeProvider`, l'errore viene effettivamente lanciato.
## Riferimenti Issue
<!-- Collega la Issue risolta (es. Closes #). -->
Closes #143

## Modifiche Effettuate
<!-- Elenca in modo sintetico le parti di codice toccate. -->
- crea `ThemeContext` con tipo `ThemeContextType | undefined` e default `undefined`
- Manitene invariato il comportamento normale del sito
- Mantiene il controllo `if (!context)` in `useTheme`

## Checklist di Controllo
<!-- Spunta le caselle sostituendo [ ] con [x] per garantire gli standard del progetto. -->
- [x] Il titolo della PR segue i Conventional Commits (`feat:`, `fix:`, `chore:`, ecc.).
- [x] Il codice supera i controlli di linting e formattazione.
- [x] La build locale completa senza errori (`pnpm build`).
- [x] Ho testato manualmente i cambiamenti prima di aprire la PR.
