### PR TITLE
fix: aggiunge spazio prima di lg:hidden

### DIFF
--- a/src/components/organisms/Navbar/SideBar.tsx
+++ b/src/components/organisms/Navbar/SideBar.tsx
@@ -47,7 +47,7 @@ export const SideBar = ({ isOpen, setIsOpen }: SideBarProps) => {
         role="dialog"
         id="sidebar"
         aria-hidden={!isOpen}
-        className={`bg-base-200 fixed inset-y-0 top-0 right-0 z-20 h-screen w-[70%] transform shadow-lg ${mounted ? 'transition-transform duration-300 ease-in-out' : ''}lg:hidden ${
+        className={`bg-base-200 fixed inset-y-0 top-0 right-0 z-20 h-screen w-[70%] transform shadow-lg ${mounted ? 'transition-transform duration-300 ease-in-out' : ''} lg:hidden ${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >


### PR DESCRIPTION
## Descrizione
<!-- Spiega brevemente lo scopo di questa PR. -->
Aggiunge uno spazio prima della classe `lg:hidden` della sidebar.
## Riferimenti Issue
<!-- Collega la Issue risolta (es. Closes #). -->
Closes #142

## Modifiche Effettuate
<!-- Elenca in modo sintetico le parti di codice toccate. -->
- aggiunge uno spazio prima della classe tailwind

## Checklist di Controllo
<!-- Spunta le caselle sostituendo [ ] con [x] per garantire gli standard del progetto. -->
- [x] Il titolo della PR segue i Conventional Commits (`feat:`, `fix:`, `chore:`, ecc.).
- [x] Il codice supera i controlli di linting e formattazione.
- [x] La build locale completa senza errori (`pnpm build`).
- [x] Ho testato manualmente i cambiamenti prima di aprire la PR.

## Note
Questo errore non e' stato rilevato da `pnpm lint`, `pnpm typecheck` ne `pnpm build` perche' nessuno di questi strumenti analizza la validata' delle classi Tailwind all'interno delle stringhe JavaScript/TypeScript.
Per prevenire problemi simili in futuro, verra' valutata l'aggiunta di un plugin dedicato come `eslint-plugin-tailwindcss`.
