### PR TITLE
fix: corregge classi Tailwind inesistenti e configura whitelist ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -72,6 +72,7 @@ export default [
 
       // Tailwindcss
       ...eslintPluginTailwindcss.configs.recommended.rules,
+      "tailwindcss/classnames-order": "off",
 
       // TypeScript
       "@typescript-eslint/no-unused-vars": "error",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -57,7 +57,7 @@ export default [
       react,
       "react-hooks": reactHooks,
       "react-refresh": reactRefresh, prettier,
-      "@typescript-eslint": tseslint, react,
+      "@typescript-eslint": tseslint,
       tailwindcss: eslintPluginTailwindcss,
     },
     rules: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -73,6 +73,23 @@ export default [
       // Tailwindcss
       ...eslintPluginTailwindcss.configs.recommended.rules,
       "tailwindcss/classnames-order": "off",
+      "tailwindcss/no-custom-classname": [
+        "warn", 
+        {
+          whitelist: [
+          'animate-scroll',
+          'swap(?:-.*)?',
+          'btn(?:-.*)?',
+          'dropdown(?:-content)?',
+          'menu',
+          'rounded-box',
+          'tooltip(?:-.*)?',
+          'card(?:-.*)?',
+          'badge(?:-outline)?',
+          'link(?:-(primary|accent))?',
+        ],
+      },
+    ],
 
       // TypeScript
       "@typescript-eslint/no-unused-vars": "error",
@@ -94,7 +111,7 @@ export default [
         version: "detect",
       },
       tailwindcss: {
-        cssConfigPath: './src/styles/app.css'
+        cssConfigPath: './src/styles/app.css',
       }
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -74,19 +74,19 @@ export default [
       ...eslintPluginTailwindcss.configs.recommended.rules,
       "tailwindcss/classnames-order": "off",
       "tailwindcss/no-custom-classname": [
-        "warn", 
+        "warn",
         {
           whitelist: [
-          'animate-scroll',
-          'swap(?:-.*)?',
-          'btn(?:-.*)?',
-          'dropdown(?:-content)?',
-          'menu',
-          'rounded-box',
-          'tooltip(?:-.*)?',
-          'card(?:-.*)?',
-          'badge(?:-outline)?',
-          'link(?:-(primary|accent))?',
+            'animate-scroll',
+            'swap(?:-.*)?',
+            'btn(?:-.*)?',
+            'dropdown(?:-content)?',
+            'menu',
+            'rounded-box',
+            'tooltip(?:-.*)?',
+            'card(?:-.*)?',
+            'badge(?:-outline)?',
+            'link(?:-(primary|accent))?',
         ],
       },
     ],
@@ -116,6 +116,6 @@ export default [
     },
   },
   {
-    ignores: ["dist", "eslint.config.js", "test-db.js", ".netlify/**/*"],
+    ignores: ["dist", "test-db.js", ".netlify/**/*"],
   },
 ];

--- a/src/components/atoms/Avatar.tsx
+++ b/src/components/atoms/Avatar.tsx
@@ -44,7 +44,7 @@ export const Avatar = ({ name }: { name?: string }) => {
         <div
           role="img"
           aria-label={`${name ? `Avatar di ${name}` : 'Avatar'}`}
-          className="bg-accent-content text-accent flex h-full w-full items-center justify-center rounded-full"
+          className="bg-accent-content text-accent flex size-full items-center justify-center rounded-full"
         >
           {initialName}
         </div>

--- a/src/components/atoms/heading/H3.tsx
+++ b/src/components/atoms/heading/H3.tsx
@@ -1,7 +1,7 @@
 export const H3 = ({ children }: { children: string }) => {
   return (
     <h3 className="text-base-content relative inline-block text-xl font-semibold capitalize">
-      <span className="relative z-[10]">{children}</span>
+      <span className="relative z-10">{children}</span>
       <span className="bg-primary absolute bottom-0 left-0 h-[2px] w-full"></span>
     </h3>
   );

--- a/src/components/molecules/Hero.tsx
+++ b/src/components/molecules/Hero.tsx
@@ -17,7 +17,7 @@ export const Hero = () => {
       {/* presentazione */}
       <header className="">
         <p className="text-4xl">
-          <span className="animate-typing text-base-content w-fit overflow-hidden border-r-2 font-mono tracking-wide whitespace-nowrap">
+          <span className="text-base-content w-fit overflow-hidden border-r-2 font-mono tracking-wide whitespace-nowrap">
             {'<Hello World>'}
           </span>{' '}
           sono
@@ -40,7 +40,7 @@ export const Hero = () => {
       <Separator />
 
       {/* call to action */}
-      <nav className="md:flex-star flex flex-col flex-wrap gap-4 md:flex-row">
+      <nav className="flex flex-col flex-wrap gap-4 md:flex-row">
         <Link to="/contact" className="btn btn-xl md:btn-lg">
           Contattami
         </Link>

--- a/src/components/molecules/Hero.tsx
+++ b/src/components/molecules/Hero.tsx
@@ -44,7 +44,7 @@ export const Hero = () => {
         <Link to="/contact" className="btn btn-xl md:btn-lg">
           Contattami
         </Link>
-        <Link to="/projects" className="btn btn-primary btn-xl md:btn-lg">
+        <Link to="/projects" className="btn btn-xl btn-primary md:btn-lg">
           Progetti
         </Link>
       </nav>

--- a/src/components/molecules/Layout.tsx
+++ b/src/components/molecules/Layout.tsx
@@ -37,7 +37,7 @@ export const Layout = ({
           classLayout
         )}
       >
-        <div className={twMerge('w-full max-w-[1024px]', classContent)}>
+        <div className={twMerge('w-full max-w-256', classContent)}>
           {children}
         </div>
       </div>

--- a/src/components/molecules/ToggleTheme.tsx
+++ b/src/components/molecules/ToggleTheme.tsx
@@ -25,7 +25,7 @@ export const ToggleTheme = () => {
 
       {/* sun icon */}
       <svg
-        className="swap-off h-8 w-8 fill-current"
+        className="swap-off size-8 fill-current"
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
       >
@@ -34,7 +34,7 @@ export const ToggleTheme = () => {
 
       {/* moon icon */}
       <svg
-        className="swap-on h-8 w-8 fill-current"
+        className="swap-on size-8 fill-current"
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
       >

--- a/src/components/molecules/ToggleTheme.tsx
+++ b/src/components/molecules/ToggleTheme.tsx
@@ -18,7 +18,6 @@ export const ToggleTheme = () => {
         id="theme-toggle"
         aria-label="Cambia tema"
         type="checkbox"
-        className="theme-controller"
         value="synthwave"
         onChange={() => setTheme(theme === 'light' ? 'dark' : 'light')}
       />

--- a/src/components/organisms/Footer.tsx
+++ b/src/components/organisms/Footer.tsx
@@ -38,7 +38,7 @@ const Footer = () => {
                   href={'https://icons8.com'}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-primary link font-bold"
+                  className="link text-primary font-bold"
                 >
                   Icons8
                 </a>

--- a/src/components/organisms/Footer.tsx
+++ b/src/components/organisms/Footer.tsx
@@ -17,7 +17,7 @@ import { Layout } from '../molecules/Layout';
 const Footer = () => {
   return (
     <Layout>
-      <footer className="bg-background flex w-full flex-row items-center justify-center text-center">
+      <footer className="flex w-full flex-row items-center justify-center text-center">
         <div className="flex w-full flex-col gap-4 px-6 py-4 md:flex-row md:justify-between">
           <div className="flex justify-center gap-4 md:order-2">
             <p className="hidden md:block">Powered by</p>

--- a/src/components/organisms/Navbar/Navbar.tsx
+++ b/src/components/organisms/Navbar/Navbar.tsx
@@ -30,7 +30,7 @@ export const Navbar = () => {
     <>
       {/* Navbar */}
       <nav className="bg-base-200/60 fixed inset-x-0 top-0 z-50 flex justify-center px-4 py-2 shadow-sm backdrop-blur-sm">
-        <div className="flex w-full max-w-[1024px] justify-between">
+        <div className="flex w-full max-w-256 justify-between">
           <Avatar name="Smailen Vargas" />
 
           <div className="flex items-center gap-4">

--- a/src/components/organisms/Navbar/SideBar.tsx
+++ b/src/components/organisms/Navbar/SideBar.tsx
@@ -55,7 +55,7 @@ export const SideBar = ({ isOpen, setIsOpen }: SideBarProps) => {
           <div className="flex items-center justify-end pr-2 pb-6">
             <button
               onClick={() => setIsOpen(false)}
-              className="btn btn-error btn-circle"
+              className="btn btn-circle btn-error"
               aria-label="Chiudi menu"
             >
               <img src={CloseIcon} alt="close" />

--- a/src/components/organisms/SectionSkill/SkillCard.tsx
+++ b/src/components/organisms/SectionSkill/SkillCard.tsx
@@ -38,7 +38,7 @@ export const SkillCard = ({ name, icon, carousel }: SkillCardProps) => {
 
   return (
     <li
-      className="lg:tooltip bg-base-300 mb-4 flex items-center justify-between rounded-md p-2 shadow-md lg:cursor-pointer"
+      className="bg-base-300 lg:tooltip mb-4 flex items-center justify-between rounded-md p-2 shadow-md lg:cursor-pointer"
       data-tip={name}
     >
       <p className="text-primary font-semibold uppercase md:hidden">{name}</p>

--- a/src/components/organisms/SectionSkill/SkillsCarousel.tsx
+++ b/src/components/organisms/SectionSkill/SkillsCarousel.tsx
@@ -31,7 +31,7 @@ export const SkillsCarousel = () => {
     <>
       <H2 textCenter>Le tecnologie che uso</H2>
 
-      <div className="mx-auto w-full overflow-x-hidden md:max-w-[976px]">
+      <div className="mx-auto w-full overflow-x-hidden md:max-w-244">
         <div className="animate-scroll inline-flex">
           {duplicatedSkills.map((skill, index) => (
             <div

--- a/src/components/organisms/SectionSkill/SkillsSection.tsx
+++ b/src/components/organisms/SectionSkill/SkillsSection.tsx
@@ -28,7 +28,7 @@ export const SkillsSection = ({ noTitle }: SkillsSectionProps) => {
 
       <Separator />
 
-      <section className="flex h-full w-full flex-col flex-wrap gap-12 md:grid md:grid-cols-3">
+      <section className="flex size-full flex-col flex-wrap gap-12 md:grid md:grid-cols-3">
         <SkillCategory section={language} title="Linguaggi" />
         <SkillCategory section={framework} title="Framework e Librerie" />
         <SkillCategory section={utility} title="Strumenti di Sviluppo" />

--- a/src/features/cv/components/CurriculumDownload.tsx
+++ b/src/features/cv/components/CurriculumDownload.tsx
@@ -18,7 +18,7 @@ export const CurriculumDownload = ({
           Curriculum
         </summary>
 
-        <ul className="menu dropdown-content bg-base-100 rounded-box z-10 w-52 p-2 shadow-sm">
+        <ul className="dropdown-content menu rounded-box bg-base-100 z-10 w-52 p-2 shadow-sm">
           <li>
             <a
               // href="/assets/curriculum/CV-Smailen-Vargas-Frontend-IT.pdf"

--- a/src/features/projects/components/Card.tsx
+++ b/src/features/projects/components/Card.tsx
@@ -73,7 +73,7 @@ export const CardProject = ({
         <div className="flex justify-center">
           <a
             href={projectUrl}
-            className="btn btn-primary btn-xl md:btn-lg w-full"
+            className="btn btn-xl btn-primary md:btn-lg w-full"
             target="_blank"
             rel="noopener noreferrer"
             aria-label={`Visualizza i dettagli di ${formattedName} su GitHub`}

--- a/src/features/projects/components/Filter.tsx
+++ b/src/features/projects/components/Filter.tsx
@@ -75,7 +75,7 @@ export const Filter = ({
   return (
     <section
       id="filter"
-      className="bg-secondary rounded-box flex w-full flex-col items-start gap-8 p-2 md:flex-row md:items-center md:justify-between md:gap-0"
+      className="rounded-box bg-secondary flex w-full flex-col items-start gap-8 p-2 md:flex-row md:items-center md:justify-between md:gap-0"
     >
       <details
         className="dropdown"
@@ -83,7 +83,7 @@ export const Filter = ({
         onToggle={e => setIsOpen(e.currentTarget.open)}
       >
         <summary className="btn m-1">Seleziona una tecnologia</summary>
-        <ul className="menu dropdown-content bg-base-100 rounded-box z-10 w-52 p-3 shadow-sm">
+        <ul className="dropdown-content menu rounded-box bg-base-100 z-10 w-52 p-3 shadow-sm">
           {technologies.map(tech => {
             return (
               <li key={tech}>

--- a/src/shared/hooks/useChangeAvatar.tsx
+++ b/src/shared/hooks/useChangeAvatar.tsx
@@ -9,7 +9,12 @@ const useChangeAvatar = () => {
 
   useEffect(() => {
     const interval = setInterval(() => {
-      setAnimation('animate-appearance-out');
+      /* 
+        TODO: le classi `animate-appearance-out`, `animate-appearance-in` non esistono piu'
+        (rimosse da un refactor precedente). l'animazione dell'avatar e' disabilitata.
+        Ripristinare definendo le animazioni in src/styles/app.css o rimuovere logica.
+        */
+      setAnimation('');
       // fa apparire il nuovo avatar
       setTimeout(() => {
         // filtra le immagini per non ripetere l'immagine corrente
@@ -19,7 +24,8 @@ const useChangeAvatar = () => {
 
         const randomIndex = Math.floor(Math.random() * filteredImages.length);
         setCurrentAvatar(filteredImages[randomIndex]);
-        setAnimation('animate-appearance-in');
+        //! anche qui va visto cosa fare con la classe
+        setAnimation('');
       }, 50);
     }, 5000);
     return () => clearInterval(interval);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6,8 +6,8 @@
   darkmode: 'data-theme';
   root: ':root';
   /* DaisyUI necessita queste chiavi anche se con valori vuoti, non rimuovere `include`, `exclude` o `prefix` */
-  include: ;
-  exclude: ;
+  include:;
+  exclude:;
   prefix: ''; /* Attenzione a non lasciare vuoto questo campo senza "" */
   logs: true;
 }


### PR DESCRIPTION
## Descrizione

Rimuove classi Tailwind non valide e configura ESLint per gestire classi DaisyUI e custom senza conflitti con Prettier.

La ricerca delle classi DaisyUI e custom realmente utilizzate nel progetto è stata effettuata da OpenCode.

## Riferimenti Issue

Closes #148

## Modifiche Effettuate

- Disabilita `tailwindcss/classnames-order` in ESLint (l'ordinamento è gestito da Prettier).
- Aggiunge whitelist per classi DaisyUI e custom in `tailwindcss/no-custom-classname`.
- Corregge `md:flex-star` in `md:flex-row` in `Hero.tsx`.
- Rimuove `animate-typing` in `Hero.tsx`.
- Rimuove `bg-background` in `Footer.tsx`.
- Rimuove `theme-controller` non utilizzato in `ToggleTheme.tsx`.
- Rimuove `animate-appearance-in` e `animate-appearance-out` da `useChangeAvatar.tsx`, lasciando un commento TODO per decidere in futuro se ripristinare l'animazione o rimuovere la logica.
- Applica shorthand `size-full` dove possibile.

## Checklist di Controllo

- [x] Il titolo della PR segue i Conventional Commits.
- [x] Il codice supera i controlli di linting e formattazione.
- [x] La build locale completa senza errori (`pnpm build`).
- [ ] Ho testato manualmente i cambiamenti prima di aprire la PR.

---

PR creata da OpenCode.
