### PR TITLE
fix: ripristina animazione fade durante cambio avatar

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -49,6 +49,7 @@ export default [
         HTMLDivElement: "readonly",
         HTMLButtonElement: "readonly",
         MouseEvent: "readonly",
+        MediaQueryListEvent: "readonly",
         Node: "readonly",
         Response: "readonly",
       },

--- a/src/shared/hooks/useChangeAvatar.tsx
+++ b/src/shared/hooks/useChangeAvatar.tsx
@@ -1,35 +1,38 @@
 import { avatarImages } from '@/data/images';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+const FADE_DURATION = 300;
+const CHANGE_INTERVAL = 5000;
 
 const useChangeAvatar = () => {
-  // gestisce le immagini
   const [currentAvatar, setCurrentAvatar] = useState(avatarImages[0]);
-  // gestisce l'animazione del nuovo avatar
   const [animation, setAnimation] = useState('');
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const interval = setInterval(() => {
-      /* 
-        TODO: le classi `animate-appearance-out`, `animate-appearance-in` non esistono piu'
-        (rimosse da un refactor precedente). l'animazione dell'avatar e' disabilitata.
-        Ripristinare definendo le animazioni in src/styles/app.css o rimuovere logica.
-        */
-      setAnimation('');
-      // fa apparire il nuovo avatar
-      setTimeout(() => {
-        // filtra le immagini per non ripetere l'immagine corrente
-        const filteredImages = avatarImages.filter(
-          image => image !== currentAvatar
-        );
+      setAnimation('animate-fade-out');
 
-        const randomIndex = Math.floor(Math.random() * filteredImages.length);
-        setCurrentAvatar(filteredImages[randomIndex]);
-        //! anche qui va visto cosa fare con la classe
-        setAnimation('');
-      }, 50);
-    }, 5000);
-    return () => clearInterval(interval);
-  }, [currentAvatar]);
+      timeoutRef.current = setTimeout(() => {
+        setCurrentAvatar(previousAvatar => {
+          const filteredImages = avatarImages.filter(
+            image => image !== previousAvatar
+          );
+          const randomIndex = Math.floor(Math.random() * filteredImages.length);
+          return filteredImages[randomIndex];
+        });
+        setAnimation('animate-fade-in');
+      }, FADE_DURATION);
+    }, CHANGE_INTERVAL);
+
+    return () => {
+      clearInterval(interval);
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
   return { currentAvatar, animation };
 };
 

--- a/src/shared/hooks/useChangeAvatar.tsx
+++ b/src/shared/hooks/useChangeAvatar.tsx
@@ -3,33 +3,65 @@ import { useEffect, useRef, useState } from 'react';
 
 const FADE_DURATION = 300;
 const CHANGE_INTERVAL = 5000;
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
 
 const useChangeAvatar = () => {
   const [currentAvatar, setCurrentAvatar] = useState(avatarImages[0]);
   const [animation, setAnimation] = useState('');
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
-    const interval = setInterval(() => {
-      setAnimation('animate-fade-out');
+    const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
 
-      timeoutRef.current = setTimeout(() => {
-        setCurrentAvatar(previousAvatar => {
-          const filteredImages = avatarImages.filter(
-            image => image !== previousAvatar
-          );
-          const randomIndex = Math.floor(Math.random() * filteredImages.length);
-          return filteredImages[randomIndex];
-        });
-        setAnimation('animate-fade-in');
-      }, FADE_DURATION);
-    }, CHANGE_INTERVAL);
+    const startCycle = () => {
+      intervalRef.current = setInterval(() => {
+        setAnimation('animate-fade-out');
 
-    return () => {
-      clearInterval(interval);
+        timeoutRef.current = setTimeout(() => {
+          setCurrentAvatar(previousAvatar => {
+            const filteredImages = avatarImages.filter(
+              image => image !== previousAvatar
+            );
+            const randomIndex = Math.floor(
+              Math.random() * filteredImages.length
+            );
+            return filteredImages[randomIndex];
+          });
+          setAnimation('animate-fade-in');
+        }, FADE_DURATION);
+      }, CHANGE_INTERVAL);
+    };
+
+    const stopCycle = () => {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
       if (timeoutRef.current !== null) {
         clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
       }
+      setAnimation('');
+    };
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        stopCycle();
+      } else {
+        startCycle();
+      }
+    };
+
+    if (!mediaQuery.matches) {
+      startCycle();
+    }
+
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      stopCycle();
+      mediaQuery.removeEventListener('change', handleChange);
     };
   }, []);
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -161,3 +161,11 @@
 .animate-fade-in {
   animation: fade-in 300ms forwards;
 }
+
+/* Rispetta la preferenza di sistema per ridurre le animazioni */
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-out,
+  .animate-fade-in {
+    animation: none;
+  }
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -134,3 +134,30 @@
   animation: scroll 20s linear infinite;
   will-change: transform;
 }
+
+/* Animazione fade per cambio avatar */
+@keyframes fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.animate-fade-out {
+  animation: fade-out 300ms forwards;
+}
+
+.animate-fade-in {
+  animation: fade-in 300ms forwards;
+}


### PR DESCRIPTION
## Descrizione
Ripristina la transizione fade out/fade in sull'avatar che era stata disabilitata dopo la rimozione delle classi `animate-appearance-out` / `animate-appearance-in` in un refactor precedente.

## Riferimenti Issue
Closes #170

## Modifiche Effettuate
- Aggiunge keyframes `fade-out` e `fade-in` con classi `.animate-fade-out` / `.animate-fade-in` in `src/styles/app.css`.
- Aggiorna `src/shared/hooks/useChangeAvatar.tsx` per eseguire la sequenza: fade-out → cambio immagine → fade-in.
- Introduce costanti `FADE_DURATION` e `CHANGE_INTERVAL` per tempistiche animate.
- Rimuove `currentAvatar` dalle dipendenze dell'`useEffect` per evitare il reset dell'interval ad ogni cambio immagine.
- Aggiunge cleanup del timeout pendente nella funzione di cleanup dell'effect.

## Checklist di Controllo
- [x] Il titolo della PR segue i Conventional Commits (`feat:`, `fix:`, `chore:`, ecc.).
- [x] Il codice supera i controlli di linting e formattazione.
- [x] La build locale completa senza errori (`pnpm build`).
- [x] Ho testato manualmente i cambiamenti prima di aprire la PR.
