### PR TITLE
refactor: migra fetchProjects per chiamare server-portfolio

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,24 @@
+# ==================================================
+# VARIABILE D'AMBIENTE - Portfolio Website
+# ==================================================
+
+# --------------------------------------------------
+# API Configuration
+# --------------------------------------------------
+# URL del server-portfolio backend
+# Obbligatorio per sviluppo e produzione
+VITE_API_URL=http://localhost:3000
+
+# --------------------------------------------------
+# CDN & Assets
+# --------------------------------------------------
+# URL del CDN per i file statici (progetti, immagini)
+# Obbligatorio per fetch dati progetti
+VITE_NETLIFY_CDN_URL=https://portfolio-cdn.netlify.app
+
+# --------------------------------------------------
+# GitHub Integration
+# --------------------------------------------------
+# URL della cartella README su GitHub per i progetti
+# Obbligatorio per link ai README dei progetti
+VITE_GITHUB_README_FOLDER=https://github.com/Smailen5/Frontend-Mentor-Challenge/tree/main/packages/

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@
 # --------------------------------------------------
 # URL del server-portfolio backend
 # Obbligatorio per sviluppo e produzione
-VITE_API_URL=https://api.smailenvargas.com
+VITE_API_URL=https://server-api.smailenvargas.com
 
 # --------------------------------------------------
 # CDN & Assets

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,24 @@
+# ==================================================
+# VARIABILE D'AMBIENTE - Portfolio Website
+# ==================================================
+
+# --------------------------------------------------
+# API Configuration
+# --------------------------------------------------
+# URL del server-portfolio backend
+# Obbligatorio per sviluppo e produzione
+VITE_API_URL=https://server-api.smailenvargas.com
+
+# --------------------------------------------------
+# CDN & Assets
+# --------------------------------------------------
+# URL del CDN per i file statici (progetti, immagini)
+# Obbligatorio per fetch dati progetti
+VITE_NETLIFY_CDN_URL=https://portfolio-cdn.netlify.app
+
+# --------------------------------------------------
+# GitHub Integration
+# --------------------------------------------------
+# URL della cartella README su GitHub per i progetti
+# Obbligatorio per link ai README dei progetti
+VITE_GITHUB_README_FOLDER=https://github.com/Smailen5/Frontend-Mentor-Challenge/tree/main/packages/

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ idee.md
 *.sln
 *.sw?
 .env
+.env.*.local
 .cursor
 .cursorrules
 .opencode/plans/PLAN*.md

--- a/src/api/getProjects.ts
+++ b/src/api/getProjects.ts
@@ -1,8 +1,8 @@
-import { CDN_URL } from '@/shared/constants/api';
+import { API_URL } from '@/shared/constants/api';
 
 export const fetchProjects = async () => {
   try {
-    const response = await fetch(CDN_URL);
+    const response = await fetch(`${API_URL}/api/projects`);
 
     if (!response.ok) throw new Error(`Richiesta fallita: ${response.status}`);
 


### PR DESCRIPTION
## Descrizione
<!-- Spiega brevemente lo scopo di questa PR. -->
Migra `getProjects` per usare l'URL della API `server-api.smailenvargas.com`. Aggiunge due nuovi file: `.env.production` e `.env.development` rimuovendo il vecchio file `.env`, aggiorna `.env.example` con il nuovo endpoint
## Riferimenti Issue
<!-- Collega la Issue risolta (es. Closes #). -->
Closes #135

## Modifiche Effettuate
<!-- Elenca in modo sintetico le parti di codice toccate. -->
- aggiorna `.gitignore` per env ambiente locale
- aggiunge `.env.production` e `.env.development` per separare le chiavi di sviluppo e produzione
- aggiorna `.env.example` con il nuovo endpoint `server-api.` invece di `api.`
- aggiorna endpoint in `getProjects.tsx` per utilizzare `server-api.smailenvargas.com`

## Checklist di Controllo
<!-- Spunta le caselle sostituendo [ ] con [x] per garantire gli standard del progetto. -->
- [x] Il titolo della PR segue i Conventional Commits (`feat:`, `fix:`, `chore:`, ecc.).
- [x] Il codice supera i controlli di linting e formattazione.
- [x] La build locale completa senza errori (`pnpm build`).
- [x] Ho testato manualmente i cambiamenti prima di aprire la PR.

## Note
Ho gia' individuato diversi bug, il server non fornisce tutte le chiavi necessarie per il frontend, alcune chiavi vanno rinominate in quanto non sono esplicative. Procedero' a queste modifiche in una nuova PR.
