### PR TITLE
refactor: rinomina proprieta nelle interfacce

### DIFF
--- a/src/shared/types/projects.ts
+++ b/src/shared/types/projects.ts
@@ -7,11 +7,9 @@ export interface CardProjectProps {
 }
 
 export interface Project extends CardProjectProps {
-  nameFolder: string;
   createdAt: string;
-  readmeUrl: string | null;
   readmeContent: string | null;
-  _v: string;
+  version: string;
 }
 
 export type CachedProjects = {


### PR DESCRIPTION
## Descrizione
<!-- Spiega brevemente lo scopo di questa PR. -->
Rimuove `nameFolder`, `readmeUrl` e `_v` dal progetto, sostituisce `_v` con `version`. Non ci sono componenti che usano queste proprieta'
## Riferimenti Issue
<!-- Collega la Issue risolta (es. Closes #). -->
Closes #178

## Modifiche Effettuate
<!-- Elenca in modo sintetico le parti di codice toccate. -->
- rimuove `nameFolder` e `readmeUrl`
- sostituisce `_v` con `version`
