### PR TITLE
chore: aggiunge template issue markdown per CLI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,8 +1,8 @@
 ---
-name: Bug Report (CLI)
+name: Fix (CLI)
 about: Segnala e risolvi un malfunzionamento
-title: 'bug: [descrizione breve]'
-labels: bug
+title: 'fix: [descrizione breve]'
+labels: fix
 assignees: Smailen5
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report (CLI)
+about: Segnala e risolvi un malfunzionamento
+title: 'bug: [descrizione breve]'
+labels: bug
+assignees: Smailen5
+---
+
+## Descrizione e Riproduzione
+<!-- Cosa si e' rotto e quali sono i passaggi per riprodurre l'errore. (obbligatorio) -->
+-
+-
+
+## Comportamento Atteso (Criteri di Accettazione)
+<!-- Come dovrebbe funzionare correttamente. (obbligatorio) -->
+-
+-
+
+## Task (Risoluzione)
+<!-- Ipotesi o passaggi tecnici per risolvere il bug. (obbligatorio) -->
+- [ ] ...
+- [ ] ...
+
+## Log / Stack Trace
+<!-- Incolla qui l'errore del terminale o della console. (facoltativo) -->

--- a/.github/ISSUE_TEMPLATE/build.md
+++ b/.github/ISSUE_TEMPLATE/build.md
@@ -1,0 +1,20 @@
+---
+name: Build (CLI)
+about: Modifiche al sistema di build o script
+title: 'build: [descrizione breve]'
+labels: build
+assignees: Smailen5
+---
+
+## Descrizione
+<!-- Cosa va modificato nel sistema di build? (obbligatorio) -->
+
+## Criteri di Accettazione
+<!-- Come verifichiamo che la build funzioni? (obbligatorio) -->
+-
+-
+
+## Task
+<!-- Passaggi tecnici per completare la modifica. (facoltativo) -->
+- [ ] ...
+- [ ] ...

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,20 @@
+---
+name: Chore (CLI)
+about: Manutenzione ordinaria e configurazione
+title: 'chore: [descrizione breve]'
+labels: chore
+assignees: Smailen5
+---
+
+## Descrizione
+<!-- Cosa va aggiornato, rimosso o modificato. (obbligatorio) -->
+
+## Criteri di Accettazione
+<!-- Come verifichiamo che il task sia completato correttamente. (obbligatorio) -->
+-
+-
+
+## Task
+<!-- Passaggi tecnici per completare l'attivita'. (facoltativo) -->
+- [ ] ...
+- [ ] ...

--- a/.github/ISSUE_TEMPLATE/ci.md
+++ b/.github/ISSUE_TEMPLATE/ci.md
@@ -1,0 +1,20 @@
+---
+name: CI/CD (CLI)
+about: Modifiche a CI/CD e GitHub Actions
+title: 'ci: [descrizione breve]'
+labels: ci
+assignees: Smailen5
+---
+
+## Descrizione
+<!-- Cosa va modificato nella CI/CD. (obbligatorio) -->
+
+## Criteri di Accettazione
+<!-- Come verifichiamo che la CI/CD funzioni. (obbligatorio) -->
+-
+-
+
+## Task
+<!-- Passaggi tecnici per completare la modifica. (facoltativo) -->
+- [ ] ...
+- [ ] ...

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -2,7 +2,7 @@
 name: Documentation (CLI)
 about: Aggiungi o aggiorna la documentazione
 title: 'docs: [descrizione breve]'
-labels: documentation
+labels: docs
 assignees: Smailen5
 ---
 

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,0 +1,20 @@
+---
+name: Documentation (CLI)
+about: Aggiungi o aggiorna la documentazione
+title: 'docs: [descrizione breve]'
+labels: documentation
+assignees: Smailen5
+---
+
+## Descrizione
+<!-- Quale parte della documentazione necessita di interventi? (obbligatorio) -->
+
+## Criteri di Accettazione
+<!-- Cosa deve includere il documento finito? (obbligatorio) -->
+-
+-
+
+## Task
+<!-- Cosa bisogna scrivere concretamente. (facoltativo) -->
+- [ ] ...
+- [ ] ...

--- a/.github/ISSUE_TEMPLATE/feat.md
+++ b/.github/ISSUE_TEMPLATE/feat.md
@@ -2,7 +2,7 @@
 name: Feature Request (CLI)
 about: Aggiungi una nuova funzionalita'
 title: 'feat: [descrizione breve]'
-labels: feature, enhancement
+labels: feat
 assignees: Smailen5
 ---
 

--- a/.github/ISSUE_TEMPLATE/feat.md
+++ b/.github/ISSUE_TEMPLATE/feat.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request (CLI)
+about: Aggiungi una nuova funzionalita'
+title: 'feat: [descrizione breve]'
+labels: feature, enhancement
+assignees: Smailen5
+---
+
+## Descrizione
+<!-- Spiega cosa vorresti aggiungere e perche'. (obbligatorio) -->
+
+## Criteri di Accettazione
+<!-- Elenca i criteri per considerare completa la issue. (obbligatorio) -->
+-
+-
+
+## Task
+<!-- Elenca i passaggi tecnici necessari per completare la feature. (facoltativo) -->
+- [ ] ...
+- [ ] ...
+
+## Note Aggiuntive
+<!-- Link a documentazione, dipendenze da installare, screenshots -->

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -1,0 +1,23 @@
+---
+name: Refactor (CLI)
+about: Migliora la struttura del codice esistente
+title: 'refactor: [descrizione breve]'
+labels: refactor
+assignees: Smailen5
+---
+
+## Descrizione
+<!-- Quale parte del codice va riscritta e perche'? (obbligatorio) -->
+
+## Criteri di Accettazione
+<!-- Come dimostriamo che il refactoring ha avuto successo senza rompere nulla? (obbligatorio) -->
+-
+-
+
+## Task
+<!-- File da toccare o passaggi tecnici. (facoltativo) -->
+- [ ] ...
+- [ ] ...
+
+## Note Aggiuntive
+<!-- Librerie esterne da valutare, link e pattern design. (facoltativo) -->

--- a/.github/ISSUE_TEMPLATE/test.md
+++ b/.github/ISSUE_TEMPLATE/test.md
@@ -1,0 +1,20 @@
+---
+name: Test (CLI)
+about: Crea o migliora la suite di test
+title: 'test: [descrizione breve]'
+labels: test
+assignees: Smailen5
+---
+
+## Descrizione
+<!-- Quali funzioni o componenti necessitano di test? (obbligatorio) -->
+
+## Criteri di Accettazione
+<!-- Quali specifici scenari devono essere verificati dal test? (obbligatorio) -->
+-
+-
+
+## Task
+<!-- Passaggi tecnici per la stesura. (facoltativo) -->
+- [ ] ...
+- [ ] ...


### PR DESCRIPTION
## Descrizione
Aggiunge i template issue in formato `.md` per la CLI di GitHub, affiancandoli ai template `.yaml` esistenti per GitHub web.

## Riferimenti Issue
Closes #183

## Modifiche Effettuate
- Creati 8 file `.md` in `.github/ISSUE_TEMPLATE/` (`bug.md`, `build.md`, `chore.md`, `ci.md`, `docs.md`, `feat.md`, `refactor.md`, `test.md`)
- Ogni template `.md` rispecchia la struttura del corrispondente `.yaml` con frontmatter (`name`, `about`, `title`, `labels`, `assignees`) e sezioni markdown con commenti HTML come placeholder
- Template allineati a quelli gia' utilizzati in `server-portfolio`
