### PR TITLE
fix: ripristina animazione typing nella scritta hero

### DIFF
--- a/src/components/molecules/Hero.tsx
+++ b/src/components/molecules/Hero.tsx
@@ -17,7 +17,10 @@ export const Hero = () => {
       {/* presentazione */}
       <header className="">
         <p className="text-4xl">
-          <span className="text-base-content w-fit overflow-hidden border-r-2 font-mono tracking-wide whitespace-nowrap">
+          <span
+            className="text-base-content typing font-mono"
+            aria-label="<Hello World>"
+          >
             {'<Hello World>'}
           </span>{' '}
           sono

--- a/src/components/molecules/Hero.tsx
+++ b/src/components/molecules/Hero.tsx
@@ -22,7 +22,8 @@ export const Hero = () => {
             aria-label="<Hello World>"
           >
             {'<Hello World>'}
-          </span>{' '}
+          </span>
+          <br />
           sono
         </p>
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -135,6 +135,35 @@
   will-change: transform;
 }
 
+/* Animazione typing per hero */
+@keyframes typing {
+  0%, 10% {
+    width: 0;
+  }
+  45%, 55% {
+    width: 13ch;
+  }
+  90%, 100% {
+    width: 0;
+  }
+}
+
+@keyframes blink-caret {
+  50% {
+    border-color: transparent;
+  }
+}
+
+.typing {
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  border-right: 2px solid;
+  animation:
+    typing 6s steps(13) infinite,
+    blink-caret 0.75s step-end infinite;
+}
+
 /* Animazione fade per cambio avatar */
 @keyframes fade-out {
   from {
@@ -164,6 +193,12 @@
 
 /* Rispetta la preferenza di sistema per ridurre le animazioni */
 @media (prefers-reduced-motion: reduce) {
+  .typing {
+    width: auto;
+    border-right: none;
+    animation: none;
+  }
+
   .animate-fade-out,
   .animate-fade-in {
     animation: none;


### PR DESCRIPTION
## Descrizione
La scritta `<Hello World>` nella hero era statica, senza l'effetto typing.
Questa PR ripristina l'animazione con un approccio CSS puro (no JavaScript).

## Riferimenti Issue
Closes #201

## Modifiche Effettuate
- Aggiunta classe `.typing` in `src/styles/app.css` con animazione `typing` (typing/untyping loop) e `blink-caret` (cursore lampeggiante)
- Aggiunto supporto `prefers-reduced-motion` per disabilitare l'animazione
- Aggiornato `src/components/molecules/Hero.tsx` per usare la classe `.typing`
- Aggiunto `aria-label` per accessibilità screen reader
- Mandato a capo "sono" per evitare che si sposti durante l'animazione

## Fonti
Approccio CSS classico con `width` animata + `steps()` + `border-right` come cursore:
- https://dev.to/lazysock/make-a-typewriter-effect-with-tailwindcss-in-5-minutes-dc
- https://vanntile.com/blog/composited-typing-animation/
- https://stackoverflow.com/questions/76753785/how-to-make-typing-animation-with-tailwind-next13-4-tailwind
