### PR TITLE
refactor: centralizza meta tags Open Graph in metaTags.ts

### DIFF
--- a/src/components/atoms/Head.tsx
+++ b/src/components/atoms/Head.tsx
@@ -3,6 +3,7 @@
 import {
   JSON_LD_PERSON,
   MOBILE_APP_TAGS,
+  OPEN_GRAPH_TAGS,
   SITE_INFO,
 } from '@/shared/constants/metaTags';
 import { Helmet } from 'react-helmet';
@@ -11,7 +12,6 @@ interface HeadProps {
   title?: string;
   description?: string;
   keywords?: string;
-  ogUrl?: string;
 }
 
 /**
@@ -22,7 +22,6 @@ export const Head = ({
   title = 'Smailen Vargas | Frontend Developer',
   description = 'Ciao, sono Smailen Vargas, Frontend Developer specializzato in React, TypeScript e Tailwind CSS',
   keywords = 'Smailen Vargas, Frontend Developer, React, TypeScript, Tailwind CSS, DaisyUi, Portfolio',
-  ogUrl,
 }: HeadProps) => {
   return (
     <Helmet>
@@ -33,16 +32,13 @@ export const Head = ({
       <meta name="author" content={SITE_INFO.author} />
 
       {/* Open Graph */}
-      <meta property="og:type" content="website" />
-      <meta property="og:locale" content={SITE_INFO.locale} />
-      <meta property="og:site_name" content={SITE_INFO.name} />
-      <meta property="og:title" content={title} />
-      <meta property="og:description" content={description} />
-      <meta property="og:url" content={SITE_INFO.url + (ogUrl ? ogUrl : '')} />
-      <meta
-        property="og:image"
-        content={`${SITE_INFO.url}/images/immagine-sito.jpeg`}
-      />
+      {OPEN_GRAPH_TAGS.map(tag => (
+        <meta
+          key={tag.property}
+          property={tag.property}
+          content={tag.content}
+        />
+      ))}
 
       {/* Mobile App */}
       {MOBILE_APP_TAGS.map(tag => (

--- a/src/components/atoms/Head.tsx
+++ b/src/components/atoms/Head.tsx
@@ -5,7 +5,6 @@ import {
   JSON_LD_PERSON,
   MOBILE_APP_TAGS,
   OPEN_GRAPH_TAGS,
-  SITE_INFO,
 } from '@/shared/constants/metaTags';
 import { Helmet } from 'react-helmet';
 

--- a/src/components/atoms/Head.tsx
+++ b/src/components/atoms/Head.tsx
@@ -5,6 +5,7 @@ import {
   JSON_LD_PERSON,
   MOBILE_APP_TAGS,
   OPEN_GRAPH_TAGS,
+  SITE_INFO,
 } from '@/shared/constants/metaTags';
 import { Helmet } from 'react-helmet';
 
@@ -12,6 +13,7 @@ interface HeadProps {
   title?: string;
   description?: string;
   keywords?: string;
+  ogUrl?: string;
 }
 
 /**
@@ -22,6 +24,7 @@ export const Head = ({
   title = 'Smailen Vargas | Frontend Developer',
   description,
   keywords,
+  ogUrl,
 }: HeadProps) => {
   return (
     <Helmet>
@@ -51,7 +54,9 @@ export const Head = ({
               ? title
               : tag.property === 'og:description' && description
                 ? description
-                : tag.content
+                : tag.property === 'og:url' && ogUrl
+                  ? SITE_INFO.url + ogUrl
+                  : tag.content
           }
         />
       ))}

--- a/src/components/atoms/Head.tsx
+++ b/src/components/atoms/Head.tsx
@@ -46,7 +46,13 @@ export const Head = ({
         <meta
           key={tag.property}
           property={tag.property}
-          content={tag.content}
+          content={
+            tag.property === 'og:title' && title
+              ? title
+              : tag.property === 'og:description' && description
+                ? description
+                : tag.content
+          }
         />
       ))}
 

--- a/src/components/atoms/Head.tsx
+++ b/src/components/atoms/Head.tsx
@@ -21,8 +21,8 @@ interface HeadProps {
  */
 export const Head = ({
   title = 'Smailen Vargas | Frontend Developer',
-  description = 'Ciao, sono Smailen Vargas, Frontend Developer specializzato in React, TypeScript e Tailwind CSS',
-  keywords = 'Smailen Vargas, Frontend Developer, React, TypeScript, Tailwind CSS, DaisyUi, Portfolio',
+  description,
+  keywords,
 }: HeadProps) => {
   return (
     <Helmet>

--- a/src/components/atoms/Head.tsx
+++ b/src/components/atoms/Head.tsx
@@ -1,6 +1,7 @@
 // src/shared/utils/Head.tsx
 
 import {
+  BASE_META_TAGS,
   JSON_LD_PERSON,
   MOBILE_APP_TAGS,
   OPEN_GRAPH_TAGS,
@@ -27,9 +28,19 @@ export const Head = ({
     <Helmet>
       {/* SEO Base */}
       <title>{title}</title>
-      <meta name="description" content={description} />
-      <meta name="keywords" content={keywords} />
-      <meta name="author" content={SITE_INFO.author} />
+      {BASE_META_TAGS.map(tag => (
+        <meta
+          key={tag.name}
+          name={tag.name}
+          content={
+            tag.name === 'description' && description
+              ? description
+              : tag.name === 'keywords' && keywords
+                ? keywords
+                : tag.content
+          }
+        />
+      ))}
 
       {/* Open Graph */}
       {OPEN_GRAPH_TAGS.map(tag => (

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -20,7 +20,6 @@ function AboutPage() {
         title="About | Smailen Vargas"
         description="Sono Smailen Vargas, Frontend Developer. React, TypeScript e Tailwind. Creo interfacce accessibili, veloci e curate. Qui trovi percorso, competenze e approccio."
         keywords="smailen vargas, frontend developer, sviluppatore frontend, react, typescript, tailwind css, tanstack router, accessibilità, performance, ui/ux, portfolio, progetti"
-        ogUrl="about"
       />
       <Layout classContent="min-h-[calc(100vh-160px)] px-6">
         <Separator />

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -20,6 +20,7 @@ function AboutPage() {
         title="About | Smailen Vargas"
         description="Sono Smailen Vargas, Frontend Developer. React, TypeScript e Tailwind. Creo interfacce accessibili, veloci e curate. Qui trovi percorso, competenze e approccio."
         keywords="smailen vargas, frontend developer, sviluppatore frontend, react, typescript, tailwind css, tanstack router, accessibilità, performance, ui/ux, portfolio, progetti"
+        ogUrl="/about"
       />
       <Layout classContent="min-h-[calc(100vh-160px)] px-6">
         <Separator />

--- a/src/routes/contact/index.tsx
+++ b/src/routes/contact/index.tsx
@@ -16,7 +16,6 @@ function ContactPage() {
         title="Contatti | Smailen Vargas"
         description="Contatta Smailen Vargas per collaborazioni, domande o progetti. Disponibile via email e social media."
         keywords="Contatti, Smailen Vargas, Email, Collaborazioni, Frontend Developer"
-        ogUrl="contact"
       />
       <Layout classContent="p-6 h-[calc(100vh-160px)] md:text-center">
         <div className="flex h-full flex-col items-center justify-center">

--- a/src/routes/contact/index.tsx
+++ b/src/routes/contact/index.tsx
@@ -16,6 +16,7 @@ function ContactPage() {
         title="Contatti | Smailen Vargas"
         description="Contatta Smailen Vargas per collaborazioni, domande o progetti. Disponibile via email e social media."
         keywords="Contatti, Smailen Vargas, Email, Collaborazioni, Frontend Developer"
+        ogUrl="/contact"
       />
       <Layout classContent="p-6 h-[calc(100vh-160px)] md:text-center">
         <div className="flex h-full flex-col items-center justify-center">

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -20,6 +20,7 @@ function ProjectPage() {
         title="Progetti | Smailen Vargas"
         description="Esplora i progetti realizzati da Smailen Vargas come Frontend Developer. Scopri le tecnologie utilizzate e i risultati ottenuti."
         keywords="Smailen Vargas, Progetti, Frontend Developer, React, TypeScript, Portfolio"
+        ogUrl="/projects"
       />
       <Layout classContent="flex flex-col flex-nowrap gap-20 px-6 pb-14 pt-20 md:items-center">
         <h1 className="sr-only">Progetti</h1>

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -20,7 +20,6 @@ function ProjectPage() {
         title="Progetti | Smailen Vargas"
         description="Esplora i progetti realizzati da Smailen Vargas come Frontend Developer. Scopri le tecnologie utilizzate e i risultati ottenuti."
         keywords="Smailen Vargas, Progetti, Frontend Developer, React, TypeScript, Portfolio"
-        ogUrl="projects"
       />
       <Layout classContent="flex flex-col flex-nowrap gap-20 px-6 pb-14 pt-20 md:items-center">
         <h1 className="sr-only">Progetti</h1>

--- a/src/shared/constants/metaTags.ts
+++ b/src/shared/constants/metaTags.ts
@@ -20,9 +20,6 @@ export const SITE_INFO = {
 // ========================================
 export const BASE_META_TAGS = [
   {
-    title: 'Smailen Vargas | Frontend Developer',
-  },
-  {
     name: 'description',
     content:
       'Ciao, sono Smailen Vargas, Frontend Developer specializzato in React, TypeScript e Tailwind CSS. Scopri i miei progetti e competenze.',

--- a/src/shared/constants/metaTags.ts
+++ b/src/shared/constants/metaTags.ts
@@ -65,7 +65,7 @@ export const OPEN_GRAPH_TAGS = [
   },
   {
     property: 'og:url',
-    content: `${SITE_INFO.url}/images/immagine-sito.jpeg`,
+    content: `${SITE_INFO.url}`,
   },
   {
     property: 'og:image',

--- a/src/shared/constants/metaTags.ts
+++ b/src/shared/constants/metaTags.ts
@@ -11,7 +11,7 @@
 export const SITE_INFO = {
   name: 'Smailen Vargas Portfolio',
   author: 'Smailen Vargas',
-  url: 'https://smailenvargas.com/',
+  url: 'https://smailenvargas.com',
   locale: 'it_IT',
   themeColor: '#ffffff',
 } as const;

--- a/src/shared/constants/metaTags.ts
+++ b/src/shared/constants/metaTags.ts
@@ -64,6 +64,10 @@ export const OPEN_GRAPH_TAGS = [
       'Ciao, sono Smailen Vargas, Frontend Developer specializzato in React, TypeScript e Tailwind CSS',
   },
   {
+    property: 'og:url',
+    content: `${SITE_INFO.url}/images/immagine-sito.jpeg`,
+  },
+  {
     property: 'og:image',
     content: `${SITE_INFO.url}/images/immagine-sito.jpeg`,
   },


### PR DESCRIPTION
## Descrizione
<!-- Spiega brevemente lo scopo di questa PR. -->
Follow-up della #187: centralizza la gestione dei meta tags in `metaTags.ts` invece di hardarli in `Head.tsx`. I meta tags sono ora definiti in un unico posto e consumati via `.map()`.
Inoltre, `BASE_META_TAGS` ora supporta override dinamici: se le pagine passano `description` o `keywords`, questi sovrascrivono i valori base, altrimenti vengono usati i valori di default.
## Riferimenti Issue
<!-- Collega la Issue risolta (es. Closes #). -->
Follow-up #187

## Modifiche Effettuate
<!-- Elenca in modo sintetico le parti di codice toccate. -->
- Aggiunto `og:url` in `OPEN_GRAPH_TAGS` con valore `SITE_INFO.url`
- Rimosso meta tag `title` da `BASE_META_TAGS` (è un tag separato, non un meta tag)
- Refactorato `Head.tsx` per usare `.map()` su `BASE_META_TAGS` e `OPEN_GRAPH_TAGS`
- Rimossi valori di default da `description` e `keywords` in `Head.tsx`
- Aggiunta logica di fallback: se le props sono passate, sovrascrivono i valori base
- Rimosso prop `ogUrl` da `Head.tsx` e dalle pagine `projects`, `about`, `contact`
- Rimosso import inutilizzato `SITE_INFO` da `Head.tsx`
