### PR TITLE
chore: rimuove export inutilizzati

### DIFF
--- a/src/data/skillsData.ts
+++ b/src/data/skillsData.ts
@@ -15,25 +15,6 @@ import pnpmIcon from '@/assets/icons/pnpm.svg';
 import shadcnIcon from '@/assets/icons/shadcn.svg';
 import viteIcon from '@/assets/icons/vite.svg';
 
-const icons = [
-  {
-    name: 'Javascript',
-    icon: jsIcon,
-  },
-  {
-    name: 'React',
-    icon: reactIcon,
-  },
-  {
-    name: 'Tailwind',
-    icon: tailwindIcon,
-  },
-  {
-    name: 'Git',
-    icon: gitIcon,
-  },
-];
-
 export const language = [
   {
     name: 'HTML5',
@@ -106,4 +87,3 @@ export const utility = [
     icon: netlifyIcon,
   },
 ];
-export default icons;

--- a/src/shared/constants/api.ts
+++ b/src/shared/constants/api.ts
@@ -1,2 +1,1 @@
 export const API_URL = import.meta.env.VITE_API_URL;
-export const CDN_URL = import.meta.env.VITE_NETLIFY_CDN_URL;

--- a/src/shared/constants/metaTags.ts
+++ b/src/shared/constants/metaTags.ts
@@ -105,12 +105,3 @@ export const JSON_LD_PERSON = {
   description:
     'Ciao, sono Smailen Vargas, Frontend Developer specializzato in React, TypeScript e Tailwind CSS. Scopri i miei progetti e competenze.',
 } as const;
-
-// ========================================
-// Helper: Tutti i meta tags globali
-// ========================================
-export const GLOBAL_META_TAGS = [
-  ...BASE_META_TAGS,
-  ...OPEN_GRAPH_TAGS,
-  ...MOBILE_APP_TAGS,
-] as const;

--- a/src/shared/constants/navigation.ts
+++ b/src/shared/constants/navigation.ts
@@ -4,5 +4,3 @@ export const NAVIGATION_LINKS = [
   { linkTo: '/contact', label: 'contact' },
   { linkTo: '/about', label: 'about' },
 ] as const;
-
-export type NavigationLink = (typeof NAVIGATION_LINKS)[number];

--- a/src/shared/types/projects.ts
+++ b/src/shared/types/projects.ts
@@ -11,8 +11,3 @@ export interface Project extends CardProjectProps {
   readmeContent: string | null;
   version: string;
 }
-
-export type CachedProjects = {
-  projects: Project[];
-  timestamp: number;
-};


### PR DESCRIPTION
## Descrizione
<!-- Spiega brevemente lo scopo di questa PR. -->
Rimuove export mai usati nel codice, verificati con `grep -r "nomeExport" src/`
## Riferimenti Issue
<!-- Collega la Issue risolta (es. Closes #). -->
Closes #187

## Modifiche Effettuate
<!-- Elenca in modo sintetico le parti di codice toccate. -->
- Rimosso `CDN_URL` da `src/shared/constants/api.ts` (residuo della migrazione #135)
- Rimosso tipo `NavigationLink` da `src/shared/constants/navigation.ts`
- Rimosso `GLOBAL_META_TAGS` da `src/shared/constants/metaTags.ts`
- Rimosso tipo `CachedProjects` da `src/shared/types/projects.ts`
- Rimosso array `icons` e `export default` da `src/data/skillsData.ts`
