### PR TITLE
chore: rivede configurazione deploy netlify e aggiunge file netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+command = "pnpm build"
+publish = "dist"


### PR DESCRIPTION
## Descrizione
<!-- Spiega brevemente lo scopo di questa PR. -->
Aggiunge la configurazione base di deploy con `netlify.toml`, sposta il deploy dal ramo `manintenance` a `main`, disabilita il deploy automatico al push o al merge su main.
Deployato il sito in produzione con `netlify deploy --prod` sul tag `v5.4.2`, ovviamente prima ho eseguito un deploy locale `netlify deploy` e una build.
## Riferimenti Issue
<!-- Collega la Issue risolta (es. Closes #). -->
Closes #202

## Modifiche Effettuate
<!-- Elenca in modo sintetico le parti di codice toccate. -->
- aggiunge configurazione `netlify.toml`
- sposta il ramo di deploy da `maintenence` a `main`
- disabilita il deploy automatico al push o al merge su main
- rende i logs privati e non piu' pubblici
- disabilita le build automatiche, ora si puo' buildare solo in locale e da CLI
- deploy del sito da `v5.4.2`
