### PR TITLE
refactor: unifica fetch progetti con hook useProjects condiviso

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+nul
 
 node_modules
 dist

--- a/src/features/projects/components/Latest.tsx
+++ b/src/features/projects/components/Latest.tsx
@@ -1,10 +1,9 @@
-import { fetchProjects } from '@/api/getProjects';
 import { H2 } from '@/components/atoms/heading';
 import Section from '@/components/atoms/Section';
 import Separator from '@/components/atoms/Separator';
 import { CardProject } from '@/features/projects/components/Card';
+import { useProjects } from '@/shared/hooks/useProjects';
 import { Project } from '@/shared/types/projects';
-import { useEffect, useState } from 'react';
 
 /**
  * Componente LastProjects - Ultimi progetti in homepage
@@ -16,19 +15,9 @@ import { useEffect, useState } from 'react';
  * @see CardProject - Componente per visualizzare singolo progetto
  */
 export const LastProjects = () => {
-  const [projects, setProjects] = useState<Project[]>([]);
+  const { projects, isLoading, error } = useProjects();
   // !Modifica qui i progetti da mostrare
   const showLastProjects = 3;
-
-  useEffect(() => {
-    fetchProjects()
-      .then(data => {
-        setProjects(data);
-      })
-      .catch(error => {
-        console.error(error);
-      });
-  }, []);
 
   return (
     <Section className="text-center">
@@ -36,11 +25,17 @@ export const LastProjects = () => {
 
       <Separator />
 
-      <main className="grid gap-10 md:grid-cols-2 lg:grid-cols-3">
-        {projects.slice(0, showLastProjects).map((project: Project) => (
-          <CardProject key={project.name} {...project} />
-        ))}
-      </main>
+      {isLoading ? null : error ? (
+        <p className="text-error">
+          Errore nel recupero dei progetti. Riprova piu&apos; tardi.
+        </p>
+      ) : (
+        <main className="grid gap-10 md:grid-cols-2 lg:grid-cols-3">
+          {projects.slice(0, showLastProjects).map((project: Project) => (
+            <CardProject key={project.name} {...project} />
+          ))}
+        </main>
+      )}
     </Section>
   );
 };

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -1,19 +1,18 @@
 // src/routes/projects/index.tsx
 
-import { fetchProjects } from '@/api/getProjects';
 import { Layout } from '@/components/molecules/Layout';
 import { HeaderProject } from '@/features/projects/components/Header';
 import { SectionProjects } from '@/features/projects/components/Section';
 import { Head } from '@/components/atoms/Head';
-import { createFileRoute, useLoaderData } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
+import { useProjects } from '@/shared/hooks/useProjects';
 
 export const Route = createFileRoute('/projects/')({
-  loader: () => fetchProjects(),
   component: ProjectPage,
 });
 
 function ProjectPage() {
-  const projects = useLoaderData({ from: '/projects/' });
+  const { projects, isLoading, error } = useProjects();
   return (
     <>
       <Head
@@ -25,7 +24,13 @@ function ProjectPage() {
       <Layout classContent="flex flex-col flex-nowrap gap-20 px-6 pb-14 pt-20 md:items-center">
         <h1 className="sr-only">Progetti</h1>
         <HeaderProject />
-        <SectionProjects projects={projects} />
+        {isLoading ? null : error ? (
+          <p className="text-error">
+            Errore nel recupero dei progetti. Riprova piu&apos; tardi
+          </p>
+        ) : (
+          <SectionProjects projects={projects} />
+        )}
       </Layout>
     </>
   );

--- a/src/shared/hooks/useProjects.tsx
+++ b/src/shared/hooks/useProjects.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { Project } from '../types/projects';
+import { fetchProjects } from '@/api/getProjects';
+
+interface ProjectsCache {
+  data: Project[];
+  timestamp: number;
+}
+
+let cache: ProjectsCache | null = null;
+const STALE_TIME_MS = 5 * 60 * 1000; // 5 minuti
+
+interface UseProjectsReturn {
+  projects: Project[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function useProjects(): UseProjectsReturn {
+  const [projects, setProjects] = useState<Project[]>(cache?.data ?? []);
+  const [isLoading, setIsLoading] = useState<boolean>(cache === null);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (cache !== null && Date.now() - cache.timestamp < STALE_TIME_MS) {
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    fetchProjects()
+      .then(data => {
+        cache = { data, timestamp: Date.now() };
+        setProjects(data);
+      })
+      .catch(err => {
+        const normalizedError =
+          err instanceof Error
+            ? err
+            : new Error('Errore nel recupero dei progetti');
+        setError(normalizedError);
+        setProjects([]);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, []);
+  return { projects, isLoading, error };
+}


### PR DESCRIPTION
## Descrizione
<!-- Spiega brevemente lo scopo di questa PR. -->
Unifica il fetch dei progetti tra la homepage `Latest.tsx` e la pagina `/projects` utilizzando un unico hook condiviso `useProjects` con cache in-memory. Elimina il loader della route e previene le doppie chiamte API navigando tra le pagine.
## Riferimenti Issue
<!-- Collega la Issue risolta (es. Closes #). -->
Closes #194

## Modifiche Effettuate
<!-- Elenca in modo sintetico le parti di codice toccate. -->
- Aggiunge `src/shared/hooks/useProjects.tsx` con cache condivisa e stale time di 5 minuti
- Sostituisce `useEffect`/`useState` in `Latest.tsx` con `useProjects`
- Rimuove il loader dalla route `/projects` e utilizza `useProjects` in `ProjectPage`
- Aggiunge gestione stati `isLoading` ed `error` in entrambi i componenti
- Aggiunge `nul` a `.gitignore` per escludere file artefatto di sistema
