### PR TITLE
refactor: rimuove commenti all'inizio dei file

### DIFF
--- a/src/data/images.ts
+++ b/src/data/images.ts
@@ -1,4 +1,3 @@
-// icone per avatar che verranno animate
 import avatarIcon from '@/assets/images/avatar/avatar-smailen.webp';
 import avatarIcon2 from '@/assets/images/avatar/avatar-smailen-2.webp';
 import avatarIcon3 from '@/assets/images/avatar/avatar-smailen-github.webp';

--- a/src/features/cv/components/CurriculumDownload.tsx
+++ b/src/features/cv/components/CurriculumDownload.tsx
@@ -1,4 +1,3 @@
-// Props per il componente CurriculumDownload
 interface CurriculumDownloadProps {
   closeSideBar?: () => void;
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,5 +1,3 @@
-// src/router.tsx
-
 import { createRouter } from '@tanstack/react-router';
 import { routeTree } from './routeTree.gen';
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,4 +1,3 @@
-//src/routes/__root.tsx
 /// <reference types="vite/client" />
 
 import Footer from '@/components/organisms/Footer';

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -1,5 +1,3 @@
-// src/routes/about.tsx
-
 import { Head } from '@/components/atoms/Head';
 import { H1, H2 } from '@/components/atoms/heading';
 import Section from '@/components/atoms/Section';

--- a/src/routes/contact/index.tsx
+++ b/src/routes/contact/index.tsx
@@ -1,5 +1,3 @@
-// src/routes/contact/index.tsx
-
 import { Head } from '@/components/atoms/Head';
 import { Layout } from '@/components/molecules/Layout';
 import SocialIcons from '@/components/molecules/Social/SocialIcon';

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,3 @@
-// src/routes/index.tsx
-
 import { Hero } from '@/components/molecules/Hero';
 import { Layout } from '@/components/molecules/Layout';
 import { Presentation } from '@/components/molecules/Presentation';

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -1,5 +1,3 @@
-// src/routes/projects/index.tsx
-
 import { Layout } from '@/components/molecules/Layout';
 import { HeaderProject } from '@/features/projects/components/Header';
 import { SectionProjects } from '@/features/projects/components/Section';

--- a/src/shared/constants/metaTags.ts
+++ b/src/shared/constants/metaTags.ts
@@ -1,5 +1,3 @@
-// src/shared/constants/metaTags.ts
-
 /**
  * Meta tags globali per il sito
  * Usati come fallback in __root.tsx

--- a/src/shared/hooks/useScroll.tsx
+++ b/src/shared/hooks/useScroll.tsx
@@ -9,15 +9,6 @@ const useScroll = () => {
 
     // Esegui il reset dello scroll al caricamento della pagina
     resetScrollPosition();
-
-    // Se vuoi fare il reset anche su altri eventi, aggiungili qui
-    // per esempio, se vuoi resettare lo scroll quando la finestra viene ridimensionata
-    // window.addEventListener("resize", resetScrollPosition);
-
-    // Pulizia dell'eventuale listener se lo hai aggiunto
-    return () => {
-      // window.removeEventListener("resize", resetScrollPosition);
-    };
   }, []); // [] assicura che l'effetto si esegua solo una volta, al montaggio del componente
 };
 

--- a/src/shared/utils/getInitials.ts
+++ b/src/shared/utils/getInitials.ts
@@ -1,5 +1,3 @@
-// Estrae le iniziali da name
-// !Fa attenzione che non ci siano troppe iniziali
 export const getInitials = (name: string) => {
   if (!name) return '';
   const words = name.split(' ');

--- a/src/shared/utils/nameCorrect.tsx
+++ b/src/shared/utils/nameCorrect.tsx
@@ -1,4 +1,3 @@
-// Non serve piu rimuovere "master", "main" o "app", il nuovo nome e' gia' pulito
 export const nameCorrect = (name: string) =>
   name
     .replace(/-/g, ' ') // Sostituisce "-" con uno spazio


### PR DESCRIPTION
## Descrizione

Rimuove i commenti residui all'inizio dei file (resti del template) e il codice commentato inutilizzato trovato con una ricerca approfondita.

## Riferimenti Issue

Closes #217

## Modifiche Effettuate

- Rimuove i commenti `// src/...` da 7 file: `router.tsx`, `routes/__root.tsx`, `routes/about.tsx`, `routes/contact/index.tsx`, `routes/index.tsx`, `routes/projects/index.tsx`, `shared/constants/metaTags.ts`
- Rimuove altri commenti all'inizio dei file: `data/images.ts`, `shared/utils/nameCorrect.tsx`, `shared/utils/getInitials.ts`, `features/cv/components/CurriculumDownload.tsx`
- Rimuove codice commentato inutilizzato: `href`/`download` in `CurriculumDownload.tsx` e listener `resize` in `shared/hooks/useScroll.tsx`
- Mantiene le direttive necessarie (`/// <reference>`, `eslint-disable`) e i commenti descrittivi nel corpo del codice

## Test Eseguiti

- `pnpm lint` — 0 errori
- `pnpm typecheck` — OK
- `pnpm build` — OK
