### PR TITLE
chore: corregge classi Tailwind non ottimizzate

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -74,6 +74,7 @@ export default [
       // Tailwindcss
       ...eslintPluginTailwindcss.configs.recommended.rules,
       "tailwindcss/classnames-order": "off",
+      "tailwindcss/enforces-shorthand": "warn",
       "tailwindcss/no-custom-classname": [
         "warn",
         {

--- a/src/components/molecules/Layout.tsx
+++ b/src/components/molecules/Layout.tsx
@@ -36,7 +36,7 @@ export const Layout = ({
         classLayout
       )}
     >
-      <div className={twMerge('w-full max-w-256', classContent)}>
+      <div className={twMerge('w-full max-w-5xl', classContent)}>
         {children}
       </div>
     </div>

--- a/src/components/organisms/Navbar/Navbar.tsx
+++ b/src/components/organisms/Navbar/Navbar.tsx
@@ -28,7 +28,7 @@ export const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <nav className="bg-base-200/60 fixed inset-x-0 top-0 z-50 flex justify-center px-4 py-2 shadow-sm backdrop-blur-sm">
-      <div className="flex w-full max-w-256 justify-between">
+      <div className="flex w-full max-w-5xl justify-between">
         <Avatar name="Smailen Vargas" />
 
         <div className="flex items-center gap-4">


### PR DESCRIPTION
## Descrizione
Sostituisce la classe Tailwind `max-w-256` con lo shorthand `max-w-5xl` (entrambe 1024px) in Navbar e Layout, come segnalato dall'estensione Tailwind IntelliSense. Attiva inoltre la regola `enforces-shorthand` di `eslint-plugin-tailwindcss` per prevenire future regressioni.

## Riferimenti Issue
Closes #208

## Modifiche Effettuate
- Sostituisce `max-w-256` con `max-w-5xl` in `src/components/organisms/Navbar/Navbar.tsx`
- Sostituisce `max-w-256` con `max-w-5xl` in `src/components/molecules/Layout.tsx`
- Attiva la regola `tailwindcss/enforces-shorthand: "warn"` in `eslint.config.js`
