### PR TITLE
chore: sostituisce max-w-256 con max-w-5xl in navbar e layout

### DIFF
--- a/src/components/molecules/Layout.tsx
+++ b/src/components/molecules/Layout.tsx
@@ -36,7 +36,7 @@ export const Layout = ({
         classLayout
       )}
     >
-      <div className={twMerge('w-full max-w-256', classContent)}>
+      <div className={twMerge('w-full max-w-5xl', classContent)}>
         {children}
       </div>
     </div>

--- a/src/components/organisms/Navbar/Navbar.tsx
+++ b/src/components/organisms/Navbar/Navbar.tsx
@@ -28,7 +28,7 @@ export const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <nav className="bg-base-200/60 fixed inset-x-0 top-0 z-50 flex justify-center px-4 py-2 shadow-sm backdrop-blur-sm">
-      <div className="flex w-full max-w-256 justify-between">
+      <div className="flex w-full max-w-5xl justify-between">
         <Avatar name="Smailen Vargas" />
 
         <div className="flex items-center gap-4">


### PR DESCRIPTION
## Descrizione
L'estensione Tailwind CSS IntelliSense segnala `max-w-256` come classe non ottimizzata: esiste lo shorthand `max-w-5xl` della scala container con valore identico (64rem = 1024px). Nessun cambiamento visivo: `max-w-5xl` = 64rem = 1024px, identico a `max-w-256`.

## Riferimenti Issue
Closes #208

## Modifiche Effettuate
- Sostituito `max-w-256` con `max-w-5xl` in `src/components/organisms/Navbar/Navbar.tsx` (riga 31)
- Sostituito `max-w-256` con `max-w-5xl` in `src/components/molecules/Layout.tsx` (riga 39)
- Verificato tutto `src/`: nessun'altra occorrenza di `max-w-256`

## Note fuori scope
- `md:max-w-244` in `src/components/organisms/SectionSkill/SkillsCarousel.tsx` (riga 34, 61rem = 976px): non esiste uno shorthand della scala container equivalente esatto; sostituirla con `max-w-5xl` o `max-w-4xl` altererebbe il rendering, violando il criterio "nessun cambiamento visivo". Eventuale decisione design rimandata.
- La regola `enforces-shorthand` di `eslint-plugin-tailwindcss` discussa nei commenti della issue è già attiva (warn) tramite `configs.recommended`, ma copre solo shorthand tipo `mt-10 mb-10` → `my-10`, non le conversioni verso la scala container: nessuna modifica necessaria a `eslint.config.js`.

## Test eseguiti
- `pnpm lint`: ✅ exit 0 (nessun warning sui file modificati)
- `pnpm typecheck`: ✅ exit 0
- `pnpm build`: ✅ exit 0
