### PR TITLE
chore: sostituisce max-w-256 con max-w-5xl nelle classi Tailwind

### DIFF
--- a/src/components/molecules/Layout.tsx
+++ b/src/components/molecules/Layout.tsx
@@ -36,7 +36,7 @@ export const Layout = ({
         classLayout
       )}
     >
-      <div className={twMerge('w-full max-w-256', classContent)}>
+      <div className={twMerge('w-full max-w-5xl', classContent)}>
         {children}
       </div>
     </div>

--- a/src/components/organisms/Navbar/Navbar.tsx
+++ b/src/components/organisms/Navbar/Navbar.tsx
@@ -28,7 +28,7 @@ export const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <nav className="bg-base-200/60 fixed inset-x-0 top-0 z-50 flex justify-center px-4 py-2 shadow-sm backdrop-blur-sm">
-      <div className="flex w-full max-w-256 justify-between">
+      <div className="flex w-full max-w-5xl justify-between">
         <Avatar name="Smailen Vargas" />
 
         <div className="flex items-center gap-4">


### PR DESCRIPTION
## Descrizione
Questa PR risolve il problema con la classe `max-w-256` segnalata come non ottimizzata da Tailwind CSS IntelliSense.

## Riferimenti Issue
Closes #208

## Modifiche Effettuate
- Sostituita `max-w-256` con `max-w-5xl` in Navbar.tsx (riga 31)
- Sostituita `max-w-256` con `max-w-5xl` in Layout.tsx (riga 39)
