### PR TITLE
fix: rimuove main annidato per validità HTML e accessibilità

### DIFF
--- a/src/features/projects/components/Latest.tsx
+++ b/src/features/projects/components/Latest.tsx
@@ -30,11 +30,11 @@ export const LastProjects = () => {
           Errore nel recupero dei progetti. Riprova piu&apos; tardi.
         </p>
       ) : (
-        <main className="grid gap-10 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-10 md:grid-cols-2 lg:grid-cols-3">
           {projects.slice(0, showLastProjects).map((project: Project) => (
             <CardProject key={project.name} {...project} />
           ))}
-        </main>
+        </div>
       )}
     </Section>
   );


### PR DESCRIPTION
## Descrizione
Questa PR risolve il problema di un `<main>` annidato all'interno del componente `Latest.tsx`, che causava HTML non valido e problemi di accessibilità per gli screen reader. Il problema è stato risolto sostituendo l'elemento `<main>` con `<div>`, mantenendo le classi CSS necessarie per il layout.

## Riferimenti Issue
Closes #189

## Modifiche Effettuate
- Sostituito `<main>` con `<div>` nelle righe 27 e 31 del file `src/features/projects/components/Latest.tsx`
- Mantenute le classi CSS `grid gap-10 md:grid-cols-2 lg:grid-cols-3` per il layout
- Eseguiti test `pnpm lint` e `pnpm typecheck` con successo
